### PR TITLE
Goal::VERSION shouldn't be frozen

### DIFF
--- a/lib/goal/version.rb
+++ b/lib/goal/version.rb
@@ -1,3 +1,3 @@
 module Goal
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
When running `bundle` on ruby 1.9.3 it doesn't work:

``` bash
goal git:(master) ruby -v
# ruby 1.9.3p448 (2013-06-27 revision 41675) [x86_64-darwin12.4.0]

goal git:(master) bundle
# There was a RuntimeError while loading goal.gemspec:
# can't modify frozen String from
# /Users/matias/code/goal/goal.gemspec:6:in `block in <main>'
```

It works fine on 2.0.0 though.
